### PR TITLE
Use python3-numpy in mouse_teleop pkg.

### DIFF
--- a/mouse_teleop/package.xml
+++ b/mouse_teleop/package.xml
@@ -12,7 +12,7 @@
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>python-numpy</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python-tk</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Precisely what the title says. Required on Foxy. Perhaps this patch should go into a separate branch.